### PR TITLE
allow dependencies to select minor, and medium and minor version numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,9 +156,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd82dba44d209fddb11c190e0a94b78651f95299598e472215667417a03ff1d"
+checksum = "fe7c2840b66236045acd2607d5866e274380afd87ef99d6226e961e2cb47df45"
 dependencies = [
  "aws-lc-sys",
  "mirai-annotations",
@@ -168,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7a4168111d7eb622a31b214057b8509c0a7e1794f44c546d742330dc793972"
+checksum = "ad3a619a9de81e1d7de1f1186dcba4506ed661a0e483d84410fdef0ee87b2f96"
 dependencies = [
  "bindgen 0.69.5",
  "cc",
@@ -183,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.7"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504e3947307ac8326a5437504c517c4b56716c9d98fac0028c2acc7ca47d70ae"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -505,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
+checksum = "1a68f1f47cdf0ec8ee4b941b2eee2a80cb796db73118c0dd09ac63fbe405be22"
 dependencies = [
  "memchr",
  "serde",
@@ -574,9 +574,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.37"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40545c26d092346d8a8dab71ee48e7685a7a9cba76e634790c215b41a4a7b4cf"
+checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
 dependencies = [
  "jobserver",
  "libc",
@@ -1665,7 +1665,7 @@ dependencies = [
  "hyper 1.5.0",
  "hyper-util",
  "log",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
@@ -2146,9 +2146,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.162"
+version = "0.2.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
+checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
 
 [[package]]
 name = "libloading"
@@ -3532,9 +3532,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.16"
+version = "0.23.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
+checksum = "7f1a745511c54ba6d4465e8d5dfbd81b45791756de28d4981af70d6dca128f1e"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4335,7 +4335,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-pki-types",
  "tokio",
 ]
@@ -5300,7 +5300,7 @@ dependencies = [
  "bs58",
  "f4jumble 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.4.0",
+ "zcash_protocol 0.4.1",
 ]
 
 [[package]]
@@ -5517,7 +5517,7 @@ dependencies = [
  "zcash_address 0.6.0",
  "zcash_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_note_encryption",
- "zcash_protocol 0.4.0",
+ "zcash_protocol 0.4.1",
  "zcash_spec",
  "zip32",
 ]
@@ -5578,9 +5578,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bc22b9155b2c7eb20105cd06de170d188c1bc86489b92aa3fda7b8da8d96acf"
+checksum = "d4bbb28b59321f47454e69c2d95c11c227bb1a21bfa3381bd43c4ac98f5caee1"
 dependencies = [
  "document-features",
  "memuse",
@@ -5658,7 +5658,7 @@ dependencies = [
  "zcash_history",
  "zcash_note_encryption",
  "zcash_primitives 0.19.0",
- "zcash_protocol 0.4.0",
+ "zcash_protocol 0.4.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,34 +24,34 @@ zingolib = { git = "https://github.com/Oscar-Pepper/zingolib.git", branch = "zai
 # zingolib = { git = "https://github.com/zingolabs/zingolib.git", tag = "zaino_dep_002_091024_95e5b0d8f9d5ee0485c6141533da2f727aeafae2", features = [ "test-elevation" ], optional = true }
 
 # RPC
-tonic = {version = "0.12.2", features = ["tls", "tls-roots", "tls-webpki-roots"], optional = true }
+tonic = {version = "0.12", features = ["tls", "tls-roots", "tls-webpki-roots"], optional = true }
 
 # File
-tempfile = "3.13.0"
+tempfile = "3"
 
 # Network
-portpicker = "0.1.1"
-http = "1.1.0"
+portpicker = "0.1"
+http = "1"
 
 # Error handling
-thiserror = "1.0.64"
+thiserror = "1"
 
 # Logging
-tracing = "0.1.40"
+tracing = "0.1"
 
 # Boilerplate reduction
-getset = "0.1.3"
+getset = "0.1"
 
 # Parsing
-json = "0.12.4"
-serde_json = "1.0.132"
+json = "0.12"
+serde_json = "1"
 
 # Encoding
-hex = "0.4.3"
+hex = "0.4"
 
 # Runtime
-tokio = { version = "1.25.0", optional = true }
-tokio-stream = { version = "0.1.16", optional = true }
+tokio = { version = "1", optional = true }
+tokio-stream = { version = "0.1", optional = true }
 
 [dev-dependencies]
 # Lightclient
@@ -59,7 +59,7 @@ zingolib = { git = "https://github.com/Oscar-Pepper/zingolib.git", branch = "zai
 # zingolib = { git = "https://github.com/zingolabs/zingolib.git", tag = "zaino_dep_002_091024_95e5b0d8f9d5ee0485c6141533da2f727aeafae2", features = [ "test-elevation" ] }
 
 # Logging
-tracing-subscriber = "0.3.15"
+tracing-subscriber = "0.3"
 
 # Runtime
-tokio = "1.25.0"
+tokio = "1"


### PR DESCRIPTION
I am thinking about dependency constraints.   In my Cargo.toml, I think I want:

For n > 0:

```
some_dep = "n"
```

For n == 0:

```
some_other_dep = "0.x"
```

So for "0" versioned deps, I get updates only when the minor version changes, but for ">= 1" versioned dependencies, I get all updates prior to a bump of the initial number.

That way my software gets all the changes that come in, that "don't" break the dependencies public API, but never (without an update to my Cargo.toml) pick up breaking changes.

It's possible that I am not being careful enough about "0" versioned dependencies...

Is it possible that a dependency that's correctly following Rust semver could break a public API with a:

```
0.n.i ---> 0.n.(i+1)
```

change?

This policy delegates to each dependencies version setter, pretty agressively.

If they're getting it right, then I'm getting all the non-breaking bug-fixes (security patches)..  if they're not, then I am not...

So, I think it's a fairly extroverted policy.

Part of my motivation is that I don't want to enforce an incompatibility among dependencies without some reason.   If I just explicitly pin to a specific semver triple in all cases, then I have a pretty constrained policy, which has the downside of rejecting incompatible dependency versions aggressively.

