### PR TITLE
DRY  config strings

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -13,7 +13,7 @@ pub(crate) const ZEBRAD_FILENAME: &str = "zebrad.toml";
 pub(crate) const ZAINOD_FILENAME: &str = "zindexer.toml";
 pub(crate) const LIGHTWALLETD_FILENAME: &str = "lightwalletd.yml";
 
-const _CONFIG_STR: &str = "\
+const _EXPECTED_CONFIG: &str = "\
 ### Blockchain Configuration
 regtest=1
 nuparams=5ba81b19:1 # Overwinter
@@ -317,7 +317,7 @@ zcash-conf-path: {validator_conf}"
 mod tests {
     use std::path::PathBuf;
 
-    use crate::{config::_CONFIG_STR, logs, network};
+    use crate::{config::_EXPECTED_CONFIG, logs, network};
 
     #[test]
     fn zcashd() {
@@ -336,7 +336,7 @@ mod tests {
 
         assert_eq!(
             std::fs::read_to_string(config_dir.path().join(super::ZCASHD_FILENAME)).unwrap(),
-            format!("{}", _CONFIG_STR),
+            format!("{}", _EXPECTED_CONFIG),
         );
     }
 
@@ -363,7 +363,7 @@ mod tests {
 
         assert_eq!(
             std::fs::read_to_string(config_dir.path().join(super::ZCASHD_FILENAME)).unwrap(),
-            format!("{}{}", _CONFIG_STR , "
+            format!("{}{}", _EXPECTED_CONFIG , "
 
 ### Zcashd Help provides documentation of the following:
 mineraddress=test_addr_1234

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,38 +13,6 @@ pub(crate) const ZEBRAD_FILENAME: &str = "zebrad.toml";
 pub(crate) const ZAINOD_FILENAME: &str = "zindexer.toml";
 pub(crate) const LIGHTWALLETD_FILENAME: &str = "lightwalletd.yml";
 
-const _EXPECTED_CONFIG: &str = "\
-### Blockchain Configuration
-regtest=1
-nuparams=5ba81b19:1 # Overwinter
-nuparams=76b809bb:2 # Sapling
-nuparams=2bb40e60:3 # Blossom
-nuparams=f5b9230b:4 # Heartwood
-nuparams=e9ff75a6:5 # Canopy
-nuparams=c2d6d0b4:6 # NU5 (Orchard)
-nuparams=c8e71055:7 # NU6
-
-### MetaData Storage and Retrieval
-# txindex:
-# https://zcash.readthedocs.io/en/latest/rtd_pages/zcash_conf_guide.html#miscellaneous-options
-txindex=1
-# insightexplorer:
-# https://zcash.readthedocs.io/en/latest/rtd_pages/insight_explorer.html?highlight=insightexplorer#additional-getrawtransaction-fields
-insightexplorer=1
-experimentalfeatures=1
-lightwalletd=1
-
-### RPC Server Interface Options:
-# https://zcash.readthedocs.io/en/latest/rtd_pages/zcash_conf_guide.html#json-rpc-options
-rpcuser=xxxxxx
-rpcpassword=xxxxxx
-rpcport=1234
-rpcallowip=127.0.0.1
-
-# Buried config option to allow non-canonical RPC-PORT:
-# https://zcash.readthedocs.io/en/latest/rtd_pages/zcash_conf_guide.html#zcash-conf-guide
-listen=0";
-
 /// Writes the Zcashd config file to the specified config directory.
 /// Returns the path to the config file.
 pub(crate) fn zcashd(
@@ -317,7 +285,39 @@ zcash-conf-path: {validator_conf}"
 mod tests {
     use std::path::PathBuf;
 
-    use crate::{config::_EXPECTED_CONFIG, logs, network};
+    use crate::{logs, network};
+
+    const EXPECTED_CONFIG: &str = "\
+### Blockchain Configuration
+regtest=1
+nuparams=5ba81b19:1 # Overwinter
+nuparams=76b809bb:2 # Sapling
+nuparams=2bb40e60:3 # Blossom
+nuparams=f5b9230b:4 # Heartwood
+nuparams=e9ff75a6:5 # Canopy
+nuparams=c2d6d0b4:6 # NU5 (Orchard)
+nuparams=c8e71055:7 # NU6
+
+### MetaData Storage and Retrieval
+# txindex:
+# https://zcash.readthedocs.io/en/latest/rtd_pages/zcash_conf_guide.html#miscellaneous-options
+txindex=1
+# insightexplorer:
+# https://zcash.readthedocs.io/en/latest/rtd_pages/insight_explorer.html?highlight=insightexplorer#additional-getrawtransaction-fields
+insightexplorer=1
+experimentalfeatures=1
+lightwalletd=1
+
+### RPC Server Interface Options:
+# https://zcash.readthedocs.io/en/latest/rtd_pages/zcash_conf_guide.html#json-rpc-options
+rpcuser=xxxxxx
+rpcpassword=xxxxxx
+rpcport=1234
+rpcallowip=127.0.0.1
+
+# Buried config option to allow non-canonical RPC-PORT:
+# https://zcash.readthedocs.io/en/latest/rtd_pages/zcash_conf_guide.html#zcash-conf-guide
+listen=0";
 
     #[test]
     fn zcashd() {
@@ -336,7 +336,7 @@ mod tests {
 
         assert_eq!(
             std::fs::read_to_string(config_dir.path().join(super::ZCASHD_FILENAME)).unwrap(),
-            format!("{}", _EXPECTED_CONFIG),
+            format!("{}", EXPECTED_CONFIG),
         );
     }
 
@@ -363,7 +363,7 @@ mod tests {
 
         assert_eq!(
             std::fs::read_to_string(config_dir.path().join(super::ZCASHD_FILENAME)).unwrap(),
-            format!("{}{}", _EXPECTED_CONFIG , "
+            format!("{}{}", EXPECTED_CONFIG , "
 
 ### Zcashd Help provides documentation of the following:
 mineraddress=test_addr_1234

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,38 @@ pub(crate) const ZEBRAD_FILENAME: &str = "zebrad.toml";
 pub(crate) const ZAINOD_FILENAME: &str = "zindexer.toml";
 pub(crate) const LIGHTWALLETD_FILENAME: &str = "lightwalletd.yml";
 
+const _CONFIG_STR: &str = "\
+### Blockchain Configuration
+regtest=1
+nuparams=5ba81b19:1 # Overwinter
+nuparams=76b809bb:2 # Sapling
+nuparams=2bb40e60:3 # Blossom
+nuparams=f5b9230b:4 # Heartwood
+nuparams=e9ff75a6:5 # Canopy
+nuparams=c2d6d0b4:6 # NU5 (Orchard)
+nuparams=c8e71055:7 # NU6
+
+### MetaData Storage and Retrieval
+# txindex:
+# https://zcash.readthedocs.io/en/latest/rtd_pages/zcash_conf_guide.html#miscellaneous-options
+txindex=1
+# insightexplorer:
+# https://zcash.readthedocs.io/en/latest/rtd_pages/insight_explorer.html?highlight=insightexplorer#additional-getrawtransaction-fields
+insightexplorer=1
+experimentalfeatures=1
+lightwalletd=1
+
+### RPC Server Interface Options:
+# https://zcash.readthedocs.io/en/latest/rtd_pages/zcash_conf_guide.html#json-rpc-options
+rpcuser=xxxxxx
+rpcpassword=xxxxxx
+rpcport=1234
+rpcallowip=127.0.0.1
+
+# Buried config option to allow non-canonical RPC-PORT:
+# https://zcash.readthedocs.io/en/latest/rtd_pages/zcash_conf_guide.html#zcash-conf-guide
+listen=0";
+
 /// Writes the Zcashd config file to the specified config directory.
 /// Returns the path to the config file.
 pub(crate) fn zcashd(
@@ -285,7 +317,7 @@ zcash-conf-path: {validator_conf}"
 mod tests {
     use std::path::PathBuf;
 
-    use crate::{logs, network};
+    use crate::{config::_CONFIG_STR, logs, network};
 
     #[test]
     fn zcashd() {
@@ -302,40 +334,9 @@ mod tests {
 
         super::zcashd(config_dir.path(), 1234, &activation_heights, None).unwrap();
 
-        assert_eq!(std::fs::read_to_string(config_dir.path().join(super::ZCASHD_FILENAME)).unwrap(),
-                        format!("\
-### Blockchain Configuration
-regtest=1
-nuparams=5ba81b19:1 # Overwinter
-nuparams=76b809bb:2 # Sapling
-nuparams=2bb40e60:3 # Blossom
-nuparams=f5b9230b:4 # Heartwood
-nuparams=e9ff75a6:5 # Canopy
-nuparams=c2d6d0b4:6 # NU5 (Orchard)
-nuparams=c8e71055:7 # NU6
-
-### MetaData Storage and Retrieval
-# txindex:
-# https://zcash.readthedocs.io/en/latest/rtd_pages/zcash_conf_guide.html#miscellaneous-options
-txindex=1
-# insightexplorer:
-# https://zcash.readthedocs.io/en/latest/rtd_pages/insight_explorer.html?highlight=insightexplorer#additional-getrawtransaction-fields
-insightexplorer=1
-experimentalfeatures=1
-lightwalletd=1
-
-### RPC Server Interface Options:
-# https://zcash.readthedocs.io/en/latest/rtd_pages/zcash_conf_guide.html#json-rpc-options
-rpcuser=xxxxxx
-rpcpassword=xxxxxx
-rpcport=1234
-rpcallowip=127.0.0.1
-
-# Buried config option to allow non-canonical RPC-PORT:
-# https://zcash.readthedocs.io/en/latest/rtd_pages/zcash_conf_guide.html#zcash-conf-guide
-listen=0"
-                        )
-
+        assert_eq!(
+            std::fs::read_to_string(config_dir.path().join(super::ZCASHD_FILENAME)).unwrap(),
+            format!("{}", _CONFIG_STR),
         );
     }
 
@@ -360,44 +361,14 @@ listen=0"
         )
         .unwrap();
 
-        assert_eq!(std::fs::read_to_string(config_dir.path().join(super::ZCASHD_FILENAME)).unwrap(),
-                        format!("\
-### Blockchain Configuration
-regtest=1
-nuparams=5ba81b19:1 # Overwinter
-nuparams=76b809bb:2 # Sapling
-nuparams=2bb40e60:3 # Blossom
-nuparams=f5b9230b:4 # Heartwood
-nuparams=e9ff75a6:5 # Canopy
-nuparams=c2d6d0b4:6 # NU5 (Orchard)
-nuparams=c8e71055:7 # NU6
-
-### MetaData Storage and Retrieval
-# txindex:
-# https://zcash.readthedocs.io/en/latest/rtd_pages/zcash_conf_guide.html#miscellaneous-options
-txindex=1
-# insightexplorer:
-# https://zcash.readthedocs.io/en/latest/rtd_pages/insight_explorer.html?highlight=insightexplorer#additional-getrawtransaction-fields
-insightexplorer=1
-experimentalfeatures=1
-lightwalletd=1
-
-### RPC Server Interface Options:
-# https://zcash.readthedocs.io/en/latest/rtd_pages/zcash_conf_guide.html#json-rpc-options
-rpcuser=xxxxxx
-rpcpassword=xxxxxx
-rpcport=1234
-rpcallowip=127.0.0.1
-
-# Buried config option to allow non-canonical RPC-PORT:
-# https://zcash.readthedocs.io/en/latest/rtd_pages/zcash_conf_guide.html#zcash-conf-guide
-listen=0
+        assert_eq!(
+            std::fs::read_to_string(config_dir.path().join(super::ZCASHD_FILENAME)).unwrap(),
+            format!("{}{}", _CONFIG_STR , "
 
 ### Zcashd Help provides documentation of the following:
 mineraddress=test_addr_1234
 minetolocalwallet=0 # This is set to false so that we can mine to a wallet, other than the zcashd wallet."
-                        )
-
+            )
         );
     }
 


### PR DESCRIPTION
Removes repetition in config strings.

There may be more that can be done: I will DRY more in subsequent commits on this branch if I see something clear and obvious.

ran zancas' `cargo nextest run --features test_fixtures -E 'not test(client_rpcs)'` from #32 before changes and got:
`15 tests run: 15 passed (4 slow), 37 skipped`

after meddling with the strings (before this commit):
`15 tests run: 14 passed (4 slow), 1 failed, 37 skipped`
Each place the new `const` is used showed the same result when disrupting the string literal.

After changes present in this commit:
`15 tests run: 15 passed (4 slow), 37 skipped`

I added a `_` (underscore) before the `const` because as it is used only in testing, a warning  for unused const is emitted without this. The other option to suppress this warning was to use something like `#[allow(dead_code)]` which I liked less.