### PR TITLE
fix rust-analyzer by changing the resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "zcash_local_net"
 version = "0.1.0"
 edition = "2021"
+resolver = "2"
 
 [features]
 client = [ "dep:zcash_client_backend", "dep:zingo-netutils", "dep:zingolib" ]


### PR DESCRIPTION
To test this, notice how your rust-analyzer deals with the `test_fixtures` cfg attribute in `src/lib.rs`, before and after the change.