### PR TITLE
Update doc comments src lib rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "zcash_local_net"
 version = "0.1.0"
 edition = "2021"
+resolver = "2"
 
 [features]
 client = [ "dep:zcash_client_backend", "dep:zingo-netutils", "dep:zingolib" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,16 @@
 //!
 //! ## Overview
 //!
-//! A Rust test utility crate designed to facilitate the launching and management of Zcash processes
+//! A Rust test utility crate that facilitates launching and managing Zcash processes
 //! on a local network (regtest/localnet mode). This crate is ideal for integration testing in the
-//! development of light-clients/light-wallets, indexers/light-nodes and validators/full-nodes as it
-//! provides a simple and configurable interface for launching and managing other proccesses in the
+//! development of:
+//!
+//!   - light-clients
+//!   - light-wallets
+//!   - light-nodes (aka indexers)
+//!   - full-nodes (aka validators)
+//!
+//! as it provides a simple and configurable interface for launching and managing other processes in the
 //! local network to simulate a Zcash environment.
 //!
 //! ## List of Processes
@@ -23,11 +29,15 @@
 //!
 //! Pre-requisities for running integration tests successfully:
 //! - Build the Zcashd, Zebrad, Zainod and Lightwalletd binaries and add to $PATH.
-//! - Run `cargo test generate_zebrad_large_chain_cache --features test_fixtures -- --ignored` or `cargo nextest run generate_zebrad_large_chain_cache --run-ignored ignored-only --features test_fixtures`.
-//! - To run the `get_subtree_roots_sapling` test, sync Zebrad in testnet mode and copy the cache to `zcash_local_net/chain_cache/testnet_get_subtree_roots_sapling`. At least 2 sapling shards must be synced to pass. See `zcash_local_net::test_fixtures::get_subtree_roots_sapling` doc comments for more details.
-//! - To run the `get_subtree_roots_orchard` test, sync Zebrad in mainnet mode and copy the cache to `zcash_local_net/chain_cache/testnet_get_subtree_roots_orchard`. At least 2 orchard shards must be synced to pass. See `zcash_local_net::test_fixtures::get_subtree_roots_orchard` doc comments for more details.
+//! - In order to geneate a cached blockchain from zebrad run:
+//! ```BASH
+//! cargo nextest run generate_zebrad_large_chain_cache --run-ignored ignored-only --features test_fixtures
+//! ```
 //!
-//! See `src/test_fixtures.rs` doc comments for running client rpc tests from external crates for indexer/validator development.
+//! - To run the `get_subtree_roots_sapling` test, sync Zebrad in testnet mode and copy the cache to `zcash_local_net/chain_cache/testnet_get_subtree_roots_sapling`. At least 2 sapling shards must be synced to pass. See [crate::test_fixtures::get_subtree_roots_sapling] doc comments for more details.
+//! - To run the `get_subtree_roots_orchard` test, sync Zebrad in mainnet mode and copy the cache to `zcash_local_net/chain_cache/testnet_get_subtree_roots_orchard`. At least 2 orchard shards must be synced to pass. See [crate::test_fixtures::get_subtree_roots_orchard] doc comments for more details.
+//!
+//! See [crate::test_fixtures] doc comments for running client rpc tests from external crates for indexer/validator development.
 //!
 //! Test should be run with the `test_fixtures` feature enabled.
 //!


### PR DESCRIPTION
Also updates to `resolver = "2"`, which is default anyway:
https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html#details